### PR TITLE
Fix mismatched delete

### DIFF
--- a/source/rasterizer.cpp
+++ b/source/rasterizer.cpp
@@ -360,7 +360,7 @@ int main(int argc, char **argv) {
         
         if (image) {
             for (int j = 0; j < nx; j++) {
-                delete image[j];
+                delete[] image[j];
             }
             delete[] image;
         }


### PR DESCRIPTION
Both dimensions are allocated with `new[]`, they both must be deallocated by `delete[]`.